### PR TITLE
Use fused-effects in typechecker

### DIFF
--- a/pie.cabal
+++ b/pie.cabal
@@ -23,7 +23,7 @@ common dependencies
   build-depends:       base                   >= 4.9  && < 5.0
                      , text                   >= 1.2  && < 1.3
                      , transformers           >= 0.5  && < 0.6
-                     , fused-effects          >= 0.4  && < 0.5
+                     , fused-effects          >= 0.5  && < 0.6
 
 
 common warning-flags

--- a/src/Language/Pie/Expr.hs
+++ b/src/Language/Pie/Expr.hs
@@ -101,13 +101,13 @@ toCore = cata toCore'
   toCore' AtomF                        = CAtom
   toCore' (QuoteF s      )             = CQuote s
   -- | ΣF-Pair
-  toCore' (PairF e1 e2   )             = CSigma (Dimmed "x") e1 (Clos e2)
+  toCore' (PairF e1 e2   )             = CSigma (Dimmed "x" 0) e1 (Clos e2)
   toCore' (SigmaF v e1 e2)             = CSigma v e1 (Clos e2)
   toCore' (ConsF e1 e2   )             = CCons e1 e2
   toCore' (CarF pr       )             = CCar pr
   toCore' (CdrF pr       )             = CCdr pr
   -- | FunF-→1
-  toCore' (ArrowF e1 e2  )             = CPi (Dimmed "x") e1 (Clos e2)
+  toCore' (ArrowF e1 e2  )             = CPi (Dimmed "x" 0) e1 (Clos e2)
   toCore' (PiF v e1 e2   )             = CPi v e1 (Clos e2)
   toCore' (LambdaF v  e  )             = CLambda v (Clos e)
   toCore' (AppF    e1 e2 )             = CApp e1 e2
@@ -133,24 +133,24 @@ fromCore :: CoreExpr -> Expr
 fromCore = cata fromCore'
  where
   fromCore' :: Algebra CoreExpr Expr
-  fromCore' (CTheF e1 e2)                        = The e1 e2
-  fromCore' (CVarF v    )                        = Var v
-  fromCore' CAtomF                               = Atom
-  fromCore' (CQuoteF s                         ) = Quote s
-  fromCore' (CSigmaF (  Dimmed  _) e1 (Clos e2)) = Pair e1 (fromCore e2)
-  fromCore' (CSigmaF v@(VarName _) e1 (Clos e2)) = Sigma v e1 (fromCore e2)
-  fromCore' (CConsF e1 e2                      ) = Cons e1 e2
-  fromCore' (CCarF pr                          ) = Car pr
-  fromCore' (CCdrF pr                          ) = Cdr pr
-  fromCore' (CPiF (  Dimmed  _) e1 (Clos e2)   ) = Arrow e1 (fromCore e2)
-  fromCore' (CPiF v@(VarName _) e1 (Clos e2)   ) = Pi v e1 (fromCore e2)
-  fromCore' (CLambdaF v  (Clos e)              ) = Lambda v (fromCore e)
-  fromCore' (CAppF    e1 e2                    ) = App e1 e2
-  fromCore' CNatF                                = Nat
+  fromCore' (CTheF e1 e2)    = The e1 e2
+  fromCore' (CVarF v    )    = Var v
+  fromCore' CAtomF           = Atom
+  fromCore' (CQuoteF s)      = Quote s
+  fromCore' (CSigmaF (Dimmed _ _) e1 (Clos e2)) = Pair e1 (fromCore e2)
+  fromCore' (CSigmaF v@(VarName _ _) e1 (Clos e2)) = Sigma v e1 (fromCore e2)
+  fromCore' (CConsF e1 e2)   = Cons e1 e2
+  fromCore' (CCarF pr)       = Car pr
+  fromCore' (CCdrF pr)       = Cdr pr
+  fromCore' (CPiF (Dimmed _ _) e1 (Clos e2)) = Arrow e1 (fromCore e2)
+  fromCore' (CPiF v@(VarName _ _) e1 (Clos e2)) = Pi v e1 (fromCore e2)
+  fromCore' (CLambdaF v (Clos e)) = Lambda v (fromCore e)
+  fromCore' (CAppF e1 e2)    = App e1 e2
+  fromCore' CNatF            = Nat
 --  fromCore' CZeroF                               = Zero
-  fromCore' CZeroF                               = Int 0
-  fromCore' (CAdd1F (Int n))                     = Int (n + 1)
-  fromCore' (CAdd1F n      )                     = Add1 n
+  fromCore' CZeroF           = Int 0
+  fromCore' (CAdd1F (Int n)) = Int (n + 1)
+  fromCore' (CAdd1F n      ) = Add1 n
   fromCore' (CWhichNatF target base (Clos step)) =
     WhichNat target base (fromCore step)
   fromCore' (CIterNatF target base (Clos step)) =

--- a/src/Language/Pie/Parse.hs
+++ b/src/Language/Pie/Parse.hs
@@ -69,7 +69,7 @@ identifier = p >>= check
     else return x
 
 varNameParser :: Parser VarName
-varNameParser = VarName . Text.pack <$> identifier
+varNameParser = flip VarName 0 . Text.pack <$> identifier
 
 mkUnaryExprParser :: Parser (Expr -> Expr) -> Parser Expr
 mkUnaryExprParser p = p <*> (space1 >> pieParser)

--- a/src/Language/Pie/Print.hs
+++ b/src/Language/Pie/Print.hs
@@ -4,6 +4,7 @@ module Language.Pie.Print
 where
 
 import           Prelude                                  ( (.) )
+import Data.Eq ((==))
 import           Data.Text.Prettyprint.Doc.Render.Text    ( renderStrict )
 import           Data.Text                                ( Text )
 import           Data.Text.Prettyprint.Doc                ( (<>)
@@ -24,8 +25,8 @@ import           Language.Pie.Expr                        ( Expr(..)
                                                           )
 
 printVarName :: VarName -> Doc a
-printVarName (VarName v) = pretty v
-printVarName (Dimmed  v) = "_" <> pretty v <> "_"
+printVarName (VarName v n) = pretty v <> if n == 0 then "" else pretty n
+printVarName (Dimmed  v _) = "_" <> pretty v <> "_"
 
 printUnaryExpr :: Doc a -> Doc a -> Doc a
 printUnaryExpr tok e1 = "(" <> tok <+> e1 <> ")"

--- a/src/Language/Pie/Symbols.hs
+++ b/src/Language/Pie/Symbols.hs
@@ -9,6 +9,7 @@ import           Prelude                                  ( Show
                                                           , Ord
                                                           , (.)
                                                           )
+import           Data.Int                                 ( Int )
 import           Data.Text                                ( Text )
 import qualified Data.Text                     as Text
 import           GHC.Exts                                 ( IsString(..) )
@@ -19,6 +20,6 @@ newtype Symbol = Symbol Text
 instance IsString Symbol where
   fromString = Symbol . Text.pack
 
-data VarName = VarName Text
-             | Dimmed Text
+data VarName = VarName Text Int
+             | Dimmed Text Int
     deriving (Show, Eq, Ord)

--- a/tests/EvalTest.hs
+++ b/tests/EvalTest.hs
@@ -47,7 +47,7 @@ test_eval = testGroup
           (VSigma
             VAtom
             (CLOS Env.empty
-                  (Dimmed "x")
+                  (Dimmed "x" 0)
                   (CCdr (CCons (mkCoreAtom "oil") CAtom))
             )
           )
@@ -128,10 +128,10 @@ mkAtom :: Text -> Expr
 mkAtom = Quote . Symbol
 
 mkVar :: Text -> Expr
-mkVar = Var . VarName
+mkVar = Var . flip VarName 0
 
 mkLambda :: Text -> Expr -> Expr
-mkLambda x = Lambda (VarName x)
+mkLambda x = Lambda (VarName x 0)
 
 mkAtomVal :: Text -> Value
 mkAtomVal = VQuote . Symbol

--- a/tests/JudgementsTest.hs
+++ b/tests/JudgementsTest.hs
@@ -116,7 +116,7 @@ mkAtom :: Text -> Expr
 mkAtom = Quote . Symbol
 
 mkVar :: Text -> Expr
-mkVar = Var . VarName
+mkVar = Var . flip VarName 0
 
 mkLambda :: Text -> Expr -> Expr
-mkLambda x = Lambda (VarName x)
+mkLambda x = Lambda (VarName x 0)

--- a/tests/ParsePrintTest.hs
+++ b/tests/ParsePrintTest.hs
@@ -19,7 +19,7 @@ genVarName :: Gen VarName
 genVarName =
   Gen.choice
     $   (\x -> x <$> Gen.text (Range.constant 1 10) Gen.alpha)
-    <$> [VarName] -- TODO: support Dimmed?
+    <$> [flip VarName 0] -- TODO: support Dimmed?
 
 genSymbol :: Gen Symbol
 genSymbol = Symbol <$> Gen.text (Range.constant 1 10) Gen.alpha


### PR DESCRIPTION
Reduce the amount of argument passing by using fused effects for reading
the environment and generating freshing variable names in the
typechecker. Also starts to remove use of Either.

Did not perform the same work in the evaluator as am unsure how
recursion-schemes and fused-effects will interact.