### PR TITLE
Italicize dimmed variables in ANSI output

### DIFF
--- a/pie.cabal
+++ b/pie.cabal
@@ -1,87 +1,87 @@
-cabal-version:       2.2
-name:                pie
-version:             0.1.0.0
-synopsis:            Pie interpreter
-description:         An implementation of the pie language from the little typer
-license:             BSD-3-Clause
-license-file:        LICENSE
-author:              John Children
-maintainer:          john.a.children@gmail.com
--- copyright:
-category:            Language
-build-type:          Simple
-extra-source-files:  ChangeLog.md
+cabal-version:      2.4
+name:               pie
+version:            0.1.0.0
+synopsis:           Pie interpreter
+description:        An implementation of the pie language from the little typer
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             John Children
+maintainer:         john.a.children@gmail.com
 
+-- copyright:
+category:           Language
+build-type:         Simple
+extra-source-files: ChangeLog.md
 
 source-repository head
   type:     git
   location: https://github.com/johnchildren/pie
 
 common haskell
-  default-language:     Haskell2010
-  default-extensions:   OverloadedStrings
-                        NoImplicitPrelude
-
+  default-language:   Haskell2010
+  default-extensions:
+    NoImplicitPrelude
+    OverloadedStrings
 
 common dependencies
-  build-depends:       base                   >= 4.9  && < 5.0
-                     , text                   >= 1.2  && < 1.3
-                     , transformers           >= 0.5  && < 0.6
-                     , fused-effects          >= 0.4  && < 0.6
-
+  build-depends:
+    , base           >=4.9 && <5.0
+    , fused-effects  >=0.4 && <0.6
+    , text           ^>=1.2
+    , transformers   ^>=0.5
 
 common warning-flags
-  ghc-options:         -Wall
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wcompat
-                       -Widentities
-                       -Wredundant-constraints
-                       -Wmissing-export-lists
-                       -Wpartial-fields
-                       -Wincomplete-patterns
-                       -Wmonomorphism-restriction
-                       -Wmissing-local-signatures
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wcompat -Widentities -Wredundant-constraints
+    -Wmissing-export-lists -Wpartial-fields -Wincomplete-patterns
+    -Wmonomorphism-restriction -Wmissing-local-signatures
 
 library
-  import:              haskell, dependencies, warning-flags
-  hs-source-dirs:      src
-  exposed-modules:     Language.Pie.Environment
-                     , Language.Pie.Eval
-                     , Language.Pie.Expr
-                     , Language.Pie.Interpreter
-                     , Language.Pie.Judgement
-                     , Language.Pie.Parse
-                     , Language.Pie.Print
-                     , Language.Pie.Symbols
-                     , Language.Pie.TypeChecker
-                     , Language.Pie.Values
-  build-depends:       containers             >= 0.6  && < 0.7
-                     , megaparsec             >= 7.0  && < 8.0
-                     , prettyprinter          >= 1.2  && < 1.3
-                     , recursion-schemes      >= 5.1  && < 5.2
+  import:          haskell, dependencies, warning-flags
+  hs-source-dirs:  src
+  exposed-modules:
+    Language.Pie.Environment
+    Language.Pie.Eval
+    Language.Pie.Expr
+    Language.Pie.Interpreter
+    Language.Pie.Judgement
+    Language.Pie.Parse
+    Language.Pie.Print
+    Language.Pie.Symbols
+    Language.Pie.TypeChecker
+    Language.Pie.Values
 
+  build-depends:
+    , containers                   ^>=0.6
+    , megaparsec                   >=7.0 && <8.0
+    , prettyprinter                ^>=1.2
+    , prettyprinter-ansi-terminal  ^>=1.1
+    , recursion-schemes            ^>=5.1
 
 executable pie-repl
-  import:              haskell, dependencies, warning-flags
-  main-is:             Main.hs
-  build-depends:       repline                >= 0.2  && < 0.3
-                     , haskeline              >= 0.7  && < 0.8
-                     , pie
-
+  import:        haskell, dependencies, warning-flags
+  main-is:       Main.hs
+  build-depends:
+    , haskeline  ^>=0.7
+    , pie
+    , repline    ^>=0.2
 
 test-suite test
-  import:              haskell, dependencies, warning-flags
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      tests
-  main-is:             Test.hs
-  build-depends:       hedgehog               >= 1.0  && < 2.0
-                     , tasty                  >= 1.2  && < 2.0
-                     , tasty-hedgehog         >= 1.0  && < 2.0
-                     , tasty-hunit            >= 0.10  && < 0.11
-                     , pie
-  other-modules:       JudgementsTest
-                       CommandmentsTest
-                       LawsTest
-                       ParsePrintTest
-                       EvalTest
+  import:         haskell, dependencies, warning-flags
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is:        Test.hs
+  build-depends:
+    , hedgehog        >=1.0  && <2.0
+    , pie
+    , tasty           >=1.2  && <2.0
+    , tasty-hedgehog  >=1.0  && <2.0
+    , tasty-hunit     ^>=0.10
+
+  other-modules:
+    CommandmentsTest
+    EvalTest
+    JudgementsTest
+    LawsTest
+    ParsePrintTest

--- a/src/Language/Pie/Print.hs
+++ b/src/Language/Pie/Print.hs
@@ -9,7 +9,6 @@ import           Data.Function                            ( (.)
                                                           )
 import           Data.Eq                                  ( (==) )
 import qualified Data.List.NonEmpty            as NonEmpty
-import           Data.Text.Prettyprint.Doc.Render.Text    ( renderStrict )
 import           Data.Text                                ( Text )
 import           Data.Text.Prettyprint.Doc                ( (<>)
                                                           , (<+>)
@@ -22,6 +21,12 @@ import           Data.Text.Prettyprint.Doc                ( (<>)
                                                           , space
                                                           , layoutPretty
                                                           , defaultLayoutOptions
+                                                          , annotate
+                                                          )
+import           Data.Text.Prettyprint.Doc.Render.Terminal
+                                                          ( AnsiStyle
+                                                          , italicized
+                                                          , renderStrict
                                                           )
 import           Data.Functor.Foldable                    ( Base
                                                           , cata
@@ -40,12 +45,13 @@ parens :: [Doc a] -> Doc a
 parens = encloseSep lparen rparen space
 
 -- for sigma and pi
-typePair :: (VarName, Doc a) -> Doc a
+typePair :: (VarName, Doc AnsiStyle) -> Doc AnsiStyle
 typePair (x, y) = enclose lparen rparen (printVarName x <+> y)
 
-printVarName :: VarName -> Doc a
+printVarName :: VarName -> Doc AnsiStyle
 printVarName (VarName v n) = pretty v <> if n == 0 then "" else pretty n
-printVarName (Dimmed  v _) = "_" <> pretty v <> "_"
+printVarName (Dimmed v n) =
+  annotate italicized (pretty v <> if n == 0 then "" else pretty n)
 
 printUnaryExpr :: Doc a -> Doc a -> Doc a
 printUnaryExpr tok e1 = parens [tok, e1]
@@ -61,7 +67,7 @@ type Algebra t a = Base t a -> a
 printPie :: Expr -> Text
 printPie = renderStrict . layoutPretty defaultLayoutOptions . cata printPie'
  where
-  printPie' :: Algebra Expr (Doc a)
+  printPie' :: Algebra Expr (Doc AnsiStyle)
   printPie' (TheF e1 e2)        = printBinaryExpr "the" e1 e2
   printPie' (VarF v    )        = printVarName v
   printPie' AtomF               = "Atom"
@@ -74,9 +80,11 @@ printPie = renderStrict . layoutPretty defaultLayoutOptions . cata printPie'
   printPie' (LambdaF vs e) =
     printBinaryExpr "lambda" (parens $ printVarName <$> NonEmpty.toList vs) e
   printPie' (PiF vs e2) =
-    printBinaryExpr "Pi" (parens [(parens (typePair <$> NonEmpty.toList vs))]) e2
-  printPie' (SigmaF vs e2) =
-    printBinaryExpr "Sigma" (parens [(parens (typePair <$> NonEmpty.toList vs))]) e2
+    printBinaryExpr "Pi" (parens [parens (typePair <$> NonEmpty.toList vs)]) e2
+  printPie' (SigmaF vs e2) = printBinaryExpr
+    "Sigma"
+    (parens [parens (typePair <$> NonEmpty.toList vs)])
+    e2
   printPie' (AppF e es)          = parens (e : NonEmpty.toList es)
   printPie' NatF                 = "Nat"
   printPie' ZeroF                = "zero"


### PR DESCRIPTION
Makes dimmed variables a bit clearer by outputting them in ANSI italics.
Obviously not really portable but works okay for now.